### PR TITLE
fix: preserve file durability on Windows

### DIFF
--- a/apps/daemon/src/queue-drain-outbox.ts
+++ b/apps/daemon/src/queue-drain-outbox.ts
@@ -9,6 +9,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { join } from 'node:path'
+import { fsyncDirectory } from '@podium/runtime/durable-fs'
 import {
   RuntimeQueueDrainAbandonedMessage,
   type RuntimeQueueDrainAbandonedMessage as QueueDrainMessage,
@@ -23,21 +24,6 @@ export interface QueueDrainOutbox {
   enqueue(report: DurableQueueDrainReport): void
   acknowledge(reportId: string): boolean
   pending(): readonly DurableQueueDrainReport[]
-}
-
-function fsyncDirectory(dir: string): void {
-  try {
-    const dirFd = openSync(dir, 'r')
-    try {
-      fsyncSync(dirFd)
-    } finally {
-      closeSync(dirFd)
-    }
-  } catch (error) {
-    // Windows does not permit opening directories as file descriptors. The
-    // temp file itself was still fsynced before the atomic rename.
-    if (process.platform !== 'win32') throw error
-  }
 }
 
 function parseReports(raw: string, path: string): DurableQueueDrainReport[] {

--- a/apps/daemon/src/shipping/executor.ts
+++ b/apps/daemon/src/shipping/executor.ts
@@ -1,16 +1,14 @@
 import { createHash } from 'node:crypto'
 import { spawnSync } from 'node:child_process'
 import {
-  closeSync,
   existsSync,
-  fsyncSync,
   mkdirSync,
-  openSync,
   readFileSync,
   realpathSync,
   writeFileSync,
 } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { fsyncDirectory } from '@podium/runtime/durable-fs'
 import { shipRepairRef, type MachineId } from '@podium/model'
 import type {
   ShippingJobClassification,
@@ -258,12 +256,7 @@ export class ShippingExecutionPlane {
     const existed = existsSync(dir)
     mkdirSync(dir, { recursive: true, mode: 0o700 })
     if (!existed) {
-      const parent = openSync(dirname(dir), 'r')
-      try {
-        fsyncSync(parent)
-      } finally {
-        closeSync(parent)
-      }
+      fsyncDirectory(dirname(dir))
       crashPoint?.('after-shipping-root-parent-fsync')
     }
     this.journal = new ShippingJobJournal(join(dir, 'jobs'), (point) => crashPoint?.(point))

--- a/apps/daemon/src/shipping/journal.ts
+++ b/apps/daemon/src/shipping/journal.ts
@@ -11,6 +11,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { fsyncDirectory } from '@podium/runtime/durable-fs'
 import {
   type ShippingJobRequestMessage as ShippingJobRequest,
   ShippingJobRequestMessage,
@@ -97,12 +98,7 @@ export class ShippingJobJournal {
     const existed = existsSync(dir)
     mkdirSync(dir, { recursive: true, mode: 0o700 })
     if (!existed) {
-      const parent = openSync(dirname(dir), 'r')
-      try {
-        fsyncSync(parent)
-      } finally {
-        closeSync(parent)
-      }
+      fsyncDirectory(dirname(dir))
       this.crashPoint?.('after-parent-directory-fsync')
     }
   }
@@ -211,12 +207,7 @@ export class ShippingJobJournal {
     this.crashPoint?.('after-file-fsync')
     renameSync(temporary, target)
     this.crashPoint?.('after-rename')
-    const directory = openSync(this.dir, 'r')
-    try {
-      fsyncSync(directory)
-    } finally {
-      closeSync(directory)
-    }
+    fsyncDirectory(this.dir)
     this.crashPoint?.('after-directory-fsync')
     return next
   }

--- a/apps/server/src/migrations/backup.test.ts
+++ b/apps/server/src/migrations/backup.test.ts
@@ -120,6 +120,19 @@ describe('backupDatabase preflight', () => {
 })
 
 describe('backupDatabase partial-copy cleanup', () => {
+  it('refuses publication when a regular-file flush fails, including on Windows', () => {
+    const { db, dbPath, dir } = tmpDb()
+    const failure = Object.assign(new Error('EIO: flush failed'), { code: 'EIO' })
+    vi.mocked(fsyncSync).mockImplementationOnce(() => { throw failure })
+    try {
+      expect(() => backupDatabase(db, dbPath, 'flush-failed', PLENTY)).toThrow(failure)
+      expect(renameSync).not.toHaveBeenCalled()
+      expect(readdirSync(dir).filter((name) => name.includes('.backup-v'))).toEqual([])
+    } finally {
+      db.close()
+    }
+  })
+
   it('never publishes the truncated file when a copy fails mid-way', () => {
     const { db, dbPath, dir } = tmpDb()
     vi.mocked(copyFileSync).mockImplementationOnce((_src, dest) => {

--- a/apps/server/src/migrations/backup.ts
+++ b/apps/server/src/migrations/backup.ts
@@ -27,6 +27,7 @@ import {
   statSync,
 } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
+import { fsyncDirectory } from '@podium/runtime/durable-fs'
 import { createLogger } from '@podium/logger'
 import type { SqlDatabase } from '@podium/runtime/sqlite'
 
@@ -121,7 +122,8 @@ export function backupDatabase(
     for (const suffix of suffixes) {
       const temp = `${partialPath}${suffix}`
       copyFileSync(`${dbPath}${suffix}`, temp)
-      const fd = openSync(temp, 'r')
+      // Windows file flushing requires a writable handle.
+      const fd = openSync(temp, 'r+')
       try {
         fsyncSync(fd)
       } finally {
@@ -138,12 +140,7 @@ export function backupDatabase(
 
     // Persist the directory entry before the update operation records this path
     // and asks the coordinator to restart onto code that may run migrations.
-    const dirFd = openSync(dir, 'r')
-    try {
-      fsyncSync(dirFd)
-    } finally {
-      closeSync(dirFd)
-    }
+    fsyncDirectory(dir)
   } catch (err) {
     log.warn('database snapshot did not complete; removing its unpublished files', {
       path: partialPath,

--- a/apps/server/src/migrations/snapshot-catalogue.ts
+++ b/apps/server/src/migrations/snapshot-catalogue.ts
@@ -28,6 +28,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { dirname } from 'node:path'
+import { fsyncDirectory } from '@podium/runtime/durable-fs'
 import { createLogger } from '@podium/logger'
 
 const log = createLogger('server:migrations')
@@ -159,19 +160,14 @@ export function writeSnapshotCatalogue(dbPath: string, records: readonly Snapsho
   const body: SnapshotCatalogue = { version: SNAPSHOT_CATALOGUE_VERSION, records: [...records] }
   try {
     writeFileSync(temp, `${JSON.stringify(body, null, 2)}\n`)
-    const fd = openSync(temp, 'r')
+    const fd = openSync(temp, 'r+')
     try {
       fsyncSync(fd)
     } finally {
       closeSync(fd)
     }
     renameSync(temp, path)
-    const dirFd = openSync(dirname(path), 'r')
-    try {
-      fsyncSync(dirFd)
-    } finally {
-      closeSync(dirFd)
-    }
+    fsyncDirectory(dirname(path))
   } catch (err) {
     rmSync(temp, { force: true })
     log.warn('snapshot verification catalogue could not be published', { path, err })

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,6 +9,7 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts"
     },
+    "./durable-fs": "./src/durable-fs.ts",
     "./sqlite": "./src/sqlite/index.ts",
     "./config": "./src/config.ts",
     "./instance": "./src/instance.ts",

--- a/packages/runtime/src/durable-fs.test.ts
+++ b/packages/runtime/src/durable-fs.test.ts
@@ -1,0 +1,39 @@
+import { closeSync, fsyncSync, openSync } from 'node:fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fsyncDirectory } from './durable-fs'
+
+vi.mock('node:fs', () => ({
+  closeSync: vi.fn(),
+  fsyncSync: vi.fn(),
+  openSync: vi.fn(() => 42),
+}))
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('fsyncDirectory', () => {
+  it('does not attempt unsupported directory operations on Windows', () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+    fsyncDirectory('directory')
+    expect(openSync).not.toHaveBeenCalled()
+    expect(fsyncSync).not.toHaveBeenCalled()
+  })
+
+  it('flushes and closes directories on POSIX', () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    fsyncDirectory('directory')
+    expect(openSync).toHaveBeenCalledWith('directory', 'r')
+    expect(fsyncSync).toHaveBeenCalledWith(42)
+    expect(closeSync).toHaveBeenCalledWith(42)
+  })
+
+  it('propagates POSIX flush failures and still closes the handle', () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    const failure = new Error('flush failed')
+    vi.mocked(fsyncSync).mockImplementationOnce(() => { throw failure })
+    expect(() => fsyncDirectory('directory')).toThrow(failure)
+    expect(closeSync).toHaveBeenCalledWith(42)
+  })
+})

--- a/packages/runtime/src/durable-fs.ts
+++ b/packages/runtime/src/durable-fs.ts
@@ -1,0 +1,18 @@
+import { closeSync, fsyncSync, openSync } from 'node:fs'
+
+/**
+ * Persist directory entries after a rename or mkdir on POSIX.
+ * Windows does not support this directory-fsync pattern through node:fs, so
+ * directory-entry durability across power loss is not guaranteed there.
+ * Callers must still fsync writable file handles before publishing files;
+ * regular-file flush failures must propagate on every platform.
+ */
+export function fsyncDirectory(dir: string): void {
+  if (process.platform === 'win32') return
+  const fd = openSync(dir, 'r')
+  try {
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+}

--- a/packages/runtime/src/machine-update.ts
+++ b/packages/runtime/src/machine-update.ts
@@ -10,6 +10,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { join } from 'node:path'
+import { fsyncDirectory } from './durable-fs'
 import { UpdateGrantMessage, type UpdateStatusMessage, type UpdateTarget } from '@podium/protocol'
 import { z } from 'zod'
 
@@ -122,14 +123,7 @@ function persist(runtimeDir: string, value: MachineUpdateJournal): void {
     closeSync(fd)
   }
   renameSync(temporary, path)
-  // Windows does not expose directory handles through Node's openSync.
-  if (process.platform === 'win32') return
-  const directory = openSync(runtimeDir, 'r')
-  try {
-    fsyncSync(directory)
-  } finally {
-    closeSync(directory)
-  }
+  fsyncDirectory(runtimeDir)
 }
 
 export interface MachineUpdateAdapter {


### PR DESCRIPTION
Fix Windows EPERM failures when flushing migration snapshots and shipping journals. Open snapshot files with writable handles and share a directory-flush helper that skips unsupported directory fsync on Windows while preserving regular-file flush failures on every platform.

Directory-entry durability across power loss remains unsupported through this Windows node:fs pattern; the helper documents that limitation. Regression coverage checks platform handling and refusal to publish a backup after a file-flush failure.

Validation on Windows with Bun 1.4.3-canary.1:
- Workspace typecheck: 26 tasks successful.
- Focused persistence tests: 33 passed, 2 backup-retention tests failed (retention expectations and subsequent EBUSY cleanup).
- `bun run test`: 123 tests passed, one test-configuration assertion failed because it expects forward slashes in the Vitest executable path. The lean-gate footer reported INCOMPLETE; this is not a green gate.
- `git diff --check`: clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/madeinorbit/codesmith/podium/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791701719&installation_model_id=424405&pr_number=17&repository=madeinorbit%2Fpodium&return_to=https%3A%2F%2Fgithub.com%2Fmadeinorbit%2Fpodium%2Fpull%2F17&signature=2a31c13b1e9c0a5ecd7234df4c4ddbe7d4fe92cc1517cdc26660017587ef9376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->